### PR TITLE
feat: add frontend helper library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/node_modules/
+**/dist/
+**/build/
+.env
+npm-debug.log*

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,12 +5,21 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.20.0"
+    "react-router-dom": "^6.20.0",
+    "date-fns": "^2.30.0",
+    "yup": "^1.3.2",
+    "react-toastify": "^9.1.3",
+    "react-table": "^7.8.0",
+    "react-select": "^5.7.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "react-scripts": "^5.0.1",
+    "@types/yup": "^0.29.13",
+    "@types/react-table": "^7.7.14",
+    "@types/react-select": "^5.0.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import Login from './components/Login';
 import ChangePassword from './components/ChangePassword';
 
@@ -19,6 +21,7 @@ const App: React.FC = () => {
       {loggedIn && (
         <button onClick={handleLogout}>Logout</button>
       )}
+      <ToastContainer />
       <Routes>
         <Route path="/login" element={<Login onLogin={() => setLoggedIn(true)} />} />
         <Route path="/change-password" element={loggedIn ? <ChangePassword /> : <Navigate to="/login" />} />

--- a/frontend/src/lib/DataTable.tsx
+++ b/frontend/src/lib/DataTable.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import {
+  useTable,
+  usePagination,
+  useSortBy,
+  useFilters,
+  Column,
+} from 'react-table';
+
+interface DataTableProps<T extends object> {
+  columns: Column<T>[];
+  data: T[];
+}
+
+export function DataTable<T extends object>({ columns, data }: DataTableProps<T>) {
+  const defaultColumn = React.useMemo(
+    () => ({
+      Filter: ({ column: { filterValue, setFilter } }: any) => (
+        <input
+          value={filterValue || ''}
+          onChange={e => setFilter(e.target.value || undefined)}
+          placeholder="Search..."
+        />
+      ),
+    }),
+    []
+  );
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    prepareRow,
+    page,
+    nextPage,
+    previousPage,
+    canNextPage,
+    canPreviousPage,
+    state: { pageIndex },
+  } = useTable(
+    { columns, data, defaultColumn, initialState: { pageIndex: 0 } },
+    useFilters,
+    useSortBy,
+    usePagination
+  );
+
+  return (
+    <div>
+      <table {...getTableProps()}>
+        <thead>
+          {headerGroups.map(headerGroup => (
+            <tr {...headerGroup.getHeaderGroupProps()}>
+              {headerGroup.headers.map(column => (
+                <th {...column.getHeaderProps(column.getSortByToggleProps())}>
+                  {column.render('Header')}
+                  <div>{column.canFilter ? column.render('Filter') : null}</div>
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody {...getTableBodyProps()}>
+          {page.map(row => {
+            prepareRow(row);
+            return (
+              <tr {...row.getRowProps()}>
+                {row.cells.map(cell => (
+                  <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <div>
+        <button onClick={() => previousPage()} disabled={!canPreviousPage}>
+          Previous
+        </button>
+        <span> Page {pageIndex + 1} </span>
+        <button onClick={() => nextPage()} disabled={!canNextPage}>
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/SelectDropdown.tsx
+++ b/frontend/src/lib/SelectDropdown.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Select from 'react-select';
+
+export interface Option {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  options: Option[];
+  onChange?: (value: Option | null) => void;
+}
+
+export function SelectDropdown(props: Props) {
+  return <Select {...props} />;
+}

--- a/frontend/src/lib/datetime.ts
+++ b/frontend/src/lib/datetime.ts
@@ -1,0 +1,11 @@
+import { format, parseISO } from 'date-fns';
+
+/**
+ * Format a date into a string using date-fns.
+ * @param date A Date object or ISO date string.
+ * @param pattern Formatting pattern, defaults to 'yyyy-MM-dd'.
+ */
+export function formatDate(date: Date | string, pattern = 'yyyy-MM-dd'): string {
+  const d = typeof date === 'string' ? parseISO(date) : date;
+  return format(d, pattern);
+}

--- a/frontend/src/lib/index.ts
+++ b/frontend/src/lib/index.ts
@@ -1,0 +1,5 @@
+export * from './datetime';
+export * from './validation';
+export * from './toast';
+export * from './DataTable';
+export * from './SelectDropdown';

--- a/frontend/src/lib/toast.ts
+++ b/frontend/src/lib/toast.ts
@@ -1,0 +1,11 @@
+import { toast } from 'react-toastify';
+
+/** Show a success toast message. */
+export function showSuccess(message: string): void {
+  toast.success(message);
+}
+
+/** Show an error toast message. */
+export function showError(message: string): void {
+  toast.error(message);
+}

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -1,0 +1,10 @@
+import * as yup from 'yup';
+
+/**
+ * Validate data using a Yup schema.
+ * @param schema Yup schema to validate against.
+ * @param data The data to validate.
+ */
+export function validate<T>(schema: yup.Schema<T>, data: unknown): Promise<T> {
+  return schema.validate(data);
+}


### PR DESCRIPTION
## Summary
- scaffold reusable frontend helper library (date formatting, validation, toast, table, select)
- wire up toast container and add supporting dependencies
- ignore node_modules and build artifacts

## Testing
- `npm test` (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_689e93eab5c8832e9bc667d2e2b11f63