### PR TITLE
Add reusable form command pattern with server-side paginated UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+frontend/node_modules/
+backend/bin/
+backend/obj/

--- a/backend/Controllers/ItemsController.cs
+++ b/backend/Controllers/ItemsController.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+
+namespace backend.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ItemsController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult GetItems(int page = 1, int pageSize = 25, string search = "")
+        {
+            var allItems = Enumerable.Range(1, 100)
+                .Select(i => new { id = i, name = $"Item {i}" });
+
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                allItems = allItems.Where(i => i.name.Contains(search, StringComparison.OrdinalIgnoreCase));
+            }
+
+            var total = allItems.Count();
+            var items = allItems
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToList();
+
+            return Ok(new { items, totalCount = total });
+        }
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,11 +5,17 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.20.0"
+    "react-router-dom": "^6.20.0",
+    "react-select": "^5.7.3",
+    "react-select-async-paginate": "^0.7.1",
+    "@tanstack/react-table": "^8.9.1",
+    "yup": "^1.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/react-select": "^5.0.3",
+    "react-scripts": "^5.0.1",
     "typescript": "^5.4.0"
   },
   "scripts": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import Login from './components/Login';
 import ChangePassword from './components/ChangePassword';
+import Examples from './components/Examples';
 
 const App: React.FC = () => {
   const [loggedIn, setLoggedIn] = React.useState(false);
@@ -22,6 +23,7 @@ const App: React.FC = () => {
       <Routes>
         <Route path="/login" element={<Login onLogin={() => setLoggedIn(true)} />} />
         <Route path="/change-password" element={loggedIn ? <ChangePassword /> : <Navigate to="/login" />} />
+        <Route path="/examples" element={loggedIn ? <Examples /> : <Navigate to="/login" />} />
         <Route path="/" element={<Navigate to="/login" />} />
       </Routes>
     </div>

--- a/frontend/src/components/ChangePassword.tsx
+++ b/frontend/src/components/ChangePassword.tsx
@@ -1,23 +1,44 @@
 import React from 'react';
+import * as yup from 'yup';
+import { useFormCommand } from '../hooks/useFormCommand';
+import { validateRelatedFields } from '../utils/validation';
 
 const ChangePassword: React.FC = () => {
   const [currentPassword, setCurrentPassword] = React.useState('');
   const [newPassword, setNewPassword] = React.useState('');
-  const [error, setError] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
   const [success, setSuccess] = React.useState(false);
+
+  const submit = useFormCommand({
+    schema: yup.object({
+      currentPassword: yup.string().required('Current password is required'),
+      newPassword: yup
+        .string()
+        .required('New password is required')
+        .min(6, 'Minimum 6 characters')
+        .test('different', 'New password must differ', function (value) {
+          const current = this.parent.currentPassword;
+          return !validateRelatedFields(current, value || '', (a, b) => a !== b, 'diff');
+        }),
+    }),
+    api: async (values: { currentPassword: string; newPassword: string }) => {
+      const res = await fetch('/api/auth/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values)
+      });
+      if (!res.ok) throw new Error('Could not change password');
+    },
+    onSuccess: () => setSuccess(true)
+  });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError('');
-    const res = await fetch('/api/auth/change-password', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ currentPassword, newPassword })
-    });
-    if (res.ok) {
-      setSuccess(true);
-    } else {
-      setError('Could not change password');
+    setError(null);
+    setSuccess(false);
+    const { errors } = await submit({ currentPassword, newPassword });
+    if (errors) {
+      setError(Array.isArray(errors) ? errors.join(', ') : String(errors));
     }
   };
 

--- a/frontend/src/components/Examples.tsx
+++ b/frontend/src/components/Examples.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import PaginatedSelect from './PaginatedSelect';
+import ServerGrid from './ServerGrid';
+
+const Examples: React.FC = () => (
+  <div>
+    <h2>Async Select</h2>
+    <PaginatedSelect />
+    <h2>Data Grid</h2>
+    <ServerGrid />
+  </div>
+);
+
+export default Examples;

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import * as yup from 'yup';
+import { useFormCommand } from '../hooks/useFormCommand';
+import { validateRegex } from '../utils/validation';
 
 interface Props {
   onLogin: () => void;
@@ -7,20 +10,35 @@ interface Props {
 const Login: React.FC<Props> = ({ onLogin }) => {
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
-  const [error, setError] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const submit = useFormCommand({
+    schema: yup.object({
+      username: yup
+        .string()
+        .required('Username is required')
+        .test('alphanumeric', 'Username must be alphanumeric', (v) =>
+          !validateRegex(v || '', /^[a-zA-Z0-9]+$/, '')
+        ),
+      password: yup.string().required('Password is required')
+    }),
+    api: async (values: { username: string; password: string }) => {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values)
+      });
+      if (!res.ok) throw new Error('Invalid credentials');
+    },
+    onSuccess: onLogin
+  });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError('');
-    const res = await fetch('/api/auth/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
-    });
-    if (res.ok) {
-      onLogin();
-    } else {
-      setError('Invalid credentials');
+    setError(null);
+    const { errors } = await submit({ username, password });
+    if (errors) {
+      setError(Array.isArray(errors) ? errors.join(', ') : String(errors));
     }
   };
 

--- a/frontend/src/components/PaginatedSelect.tsx
+++ b/frontend/src/components/PaginatedSelect.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { AsyncPaginate } from 'react-select-async-paginate';
+
+const loadOptions = async (inputValue: string, _loaded: any, additional: any) => {
+  const page = additional.page || 1;
+  const res = await fetch(`/api/items?page=${page}&pageSize=10&search=${encodeURIComponent(inputValue)}`);
+  const data = await res.json();
+  return {
+    options: data.items.map((i: any) => ({ value: i.id, label: i.name })),
+    hasMore: page * 10 < data.totalCount,
+    additional: { page: page + 1 }
+  };
+};
+
+const PaginatedSelect: React.FC = () => (
+  <AsyncPaginate loadOptions={loadOptions} additional={{ page: 1 }} />
+);
+
+export default PaginatedSelect;

--- a/frontend/src/components/ServerGrid.tsx
+++ b/frontend/src/components/ServerGrid.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useReactTable, ColumnDef, getCoreRowModel } from '@tanstack/react-table';
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+const ServerGrid: React.FC = () => {
+  const [data, setData] = React.useState<Item[]>([]);
+  const [page, setPage] = React.useState(1);
+  const [total, setTotal] = React.useState(0);
+
+  const columns = React.useMemo<ColumnDef<Item>[]>(
+    () => [
+      { accessorKey: 'id', header: 'ID' },
+      { accessorKey: 'name', header: 'Name' },
+    ],
+    []
+  );
+
+  React.useEffect(() => {
+    fetch(`/api/items?page=${page}&pageSize=5`)
+      .then(r => r.json())
+      .then(json => {
+        setData(json.items);
+        setTotal(json.totalCount);
+      });
+  }, [page]);
+
+  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+
+  return (
+    <div>
+      <table>
+        <thead>
+          {table.getHeaderGroups().map(hg => (
+            <tr key={hg.id}>
+              {hg.headers.map(header => (
+                <th key={header.id}>{header.column.columnDef.header as string}</th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map(row => (
+            <tr key={row.id}>
+              {row.getVisibleCells().map(cell => (
+                <td key={cell.id}>{cell.getValue() as any}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button disabled={page <= 1} onClick={() => setPage(p => p - 1)}>
+        Prev
+      </button>
+      <button disabled={page * 5 >= total} onClick={() => setPage(p => p + 1)}>
+        Next
+      </button>
+    </div>
+  );
+};
+
+export default ServerGrid;

--- a/frontend/src/hooks/useFormCommand.ts
+++ b/frontend/src/hooks/useFormCommand.ts
@@ -1,0 +1,25 @@
+import * as yup from 'yup';
+
+export interface CommandConfig<T> {
+  schema: yup.ObjectSchema<T>;
+  api: (values: T) => Promise<any>;
+  onSuccess?: (result: any) => void;
+}
+
+export function useFormCommand<T>(config: CommandConfig<T>) {
+  return async (values: T) => {
+    try {
+      const validated = await config.schema.validate(values, {
+        abortEarly: false,
+      });
+      const result = await config.api(validated);
+      config.onSuccess?.(result);
+      return { result };
+    } catch (err: any) {
+      if (err.name === 'ValidationError') {
+        return { errors: err.errors };
+      }
+      throw err;
+    }
+  };
+}

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -1,0 +1,12 @@
+export const validateRelatedFields = <T>(
+  a: T,
+  b: T,
+  predicate: (a: T, b: T) => boolean,
+  message: string
+) => (predicate(a, b) ? null : message);
+
+export const validateDateTime = (value: string, message: string) =>
+  isNaN(Date.parse(value)) ? message : null;
+
+export const validateRegex = (value: string, regex: RegExp, message: string) =>
+  regex.test(value) ? null : message;


### PR DESCRIPTION
## Summary
- add validation helpers and command-style form submission hook
- implement login and password change forms using schema validation
- add sample async select and data grid components backed by a paginated API

## Testing
- `npm install` *(fails: 403 Forbidden fetching @tanstack/react-table)*
- `npm test` *(fails: react-scripts not found)*
- `dotnet build backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e960743a8832e91137e274298b0fe