### PR TITLE
Add access and refresh token flow

### DIFF
--- a/backend/Endpoints/AuthEndpoints.cs
+++ b/backend/Endpoints/AuthEndpoints.cs
@@ -1,11 +1,15 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using System;
 using System.Security.Claims;
 using backend.Models;
 using backend.Services;
 using Microsoft.AspNetCore.Identity;
 using backend.Clients;
 using Microsoft.Extensions.Configuration;
+using System.Linq;
+using System.Text.Json;
+using System.IdentityModel.Tokens.Jwt;
 
 namespace backend.Endpoints;
 
@@ -15,10 +19,13 @@ public static class AuthEndpoints
     {
         var group = endpoints.MapGroup("/api/auth");
 
-        group.MapPost("/login", async (LoginRequest request, UserService userService) =>
+        group.MapPost("/login", async (LoginRequest request, UserService userService, JwtService jwtService) =>
         {
             var success = await userService.LoginAsync(request);
-            return success ? Results.Ok() : Results.Unauthorized();
+            if (!success) return Results.Unauthorized();
+            var profile = new UserProfile { Id = Guid.NewGuid().ToString(), Name = request.Username, Email = string.Empty };
+            var tokens = jwtService.GenerateTokenPair(profile, Enumerable.Empty<MenuItem>());
+            return Results.Ok(tokens);
         }).AllowAnonymous();
 
         group.MapPost("/logout", async (UserService userService) =>
@@ -40,9 +47,25 @@ public static class AuthEndpoints
             var authResponse = await authClient.ExchangeKeyAsync(key, ct);
             if (authResponse is null) return Results.Unauthorized();
 
-            var token = jwtService.GenerateToken(authResponse.Profile, authResponse.Menu);
+            var tokens = jwtService.GenerateTokenPair(authResponse.Profile, authResponse.Menu);
             var redirect = config["Frontend:AuthRedirect"] ?? "/";
-            return Results.Redirect($"{redirect}?token={token}");
+            return Results.Redirect($"{redirect}?token={tokens.AccessToken}&refreshToken={tokens.RefreshToken}");
+        }).AllowAnonymous();
+
+        group.MapPost("/refresh", (RefreshRequest request, JwtService jwtService) =>
+        {
+            var principal = jwtService.ValidateRefreshToken(request.RefreshToken);
+            if (principal is null) return Results.Unauthorized();
+            var profile = new UserProfile
+            {
+                Id = principal.FindFirstValue(JwtRegisteredClaimNames.Sub) ?? string.Empty,
+                Name = principal.FindFirst("name")?.Value ?? string.Empty,
+                Email = principal.FindFirst("email")?.Value ?? string.Empty
+            };
+            var menuJson = principal.FindFirst("menu")?.Value ?? "[]";
+            var menu = JsonSerializer.Deserialize<IEnumerable<MenuItem>>(menuJson) ?? Enumerable.Empty<MenuItem>();
+            var tokens = jwtService.GenerateTokenPair(profile, menu);
+            return Results.Ok(tokens);
         }).AllowAnonymous();
     }
 }

--- a/backend/Models/RefreshRequest.cs
+++ b/backend/Models/RefreshRequest.cs
@@ -1,0 +1,4 @@
+namespace backend.Models
+{
+    public record RefreshRequest(string RefreshToken);
+}

--- a/backend/Models/TokenPair.cs
+++ b/backend/Models/TokenPair.cs
@@ -1,0 +1,4 @@
+namespace backend.Models
+{
+    public record TokenPair(string AccessToken, string RefreshToken);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,14 @@ import { useNavigate } from 'react-router-dom';
 import AppRoutes from './routes/AppRoutes';
 import { AuthProvider, useAuth } from './store/auth';
 import MainLayout from './layouts/MainLayout';
+import { api } from './api';
 
 const AppContent: React.FC = () => {
   const navigate = useNavigate();
   const { loggedIn, logout } = useAuth();
 
   const handleLogout = () => {
-    fetch('/api/auth/logout', { method: 'POST' }).then(() => {
+    api('/api/auth/logout', { method: 'POST' }).then(() => {
       logout();
       navigate('/login');
     });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,9 +1,30 @@
-export async function api<T>(url: string, options?: RequestInit): Promise<T> {
+import { getAuthTokens, setAuthTokens } from './store/auth';
+
+export async function api<T>(url: string, options: RequestInit = {}, retry = true): Promise<T> {
+  const tokens = getAuthTokens();
   const res = await fetch(url, {
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json', ...(options?.headers || {}) },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(tokens?.accessToken ? { Authorization: `Bearer ${tokens.accessToken}` } : {}),
+      ...(options.headers || {})
+    },
     ...options
   });
+
+  if (res.status === 401 && retry && tokens?.refreshToken) {
+    const refreshRes = await fetch('/api/auth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken: tokens.refreshToken })
+    });
+    if (refreshRes.ok) {
+      const newTokens = await refreshRes.json();
+      setAuthTokens(newTokens);
+      return api<T>(url, options, false);
+    }
+  }
+
   if (!res.ok) throw new Error(res.statusText);
-  return res.json();
+  const text = await res.text();
+  return text ? JSON.parse(text) : (undefined as unknown as T);
 }

--- a/frontend/src/components/PaginatedSelect.tsx
+++ b/frontend/src/components/PaginatedSelect.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { AsyncPaginate } from 'react-select-async-paginate';
+import { api } from '../api';
 
 const loadOptions = async (inputValue: string, _loaded: any, additional: any) => {
   const page = additional.page || 1;
-  const res = await fetch(`/api/items?page=${page}&pageSize=10&search=${encodeURIComponent(inputValue)}`);
-  const data = await res.json();
+  const data = await api<any>(`/api/items?page=${page}&pageSize=10&search=${encodeURIComponent(inputValue)}`);
   return {
     options: data.items.map((i: any) => ({ value: i.id, label: i.name })),
     hasMore: page * 10 < data.totalCount,

--- a/frontend/src/components/ServerGrid.tsx
+++ b/frontend/src/components/ServerGrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useReactTable, ColumnDef, getCoreRowModel } from '@tanstack/react-table';
+import { api } from '../api';
 
 interface Item {
   id: number;
@@ -20,12 +21,10 @@ const ServerGrid: React.FC = () => {
   );
 
   React.useEffect(() => {
-    fetch(`/api/items?page=${page}&pageSize=5`)
-      .then(r => r.json())
-      .then(json => {
-        setData(json.items);
-        setTotal(json.totalCount);
-      });
+    api<any>(`/api/items?page=${page}&pageSize=5`).then(json => {
+      setData(json.items);
+      setTotal(json.totalCount);
+    });
   }, [page]);
 
   const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });

--- a/frontend/src/features/auth/AuthRedirect.tsx
+++ b/frontend/src/features/auth/AuthRedirect.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../../store/auth';
+
+const AuthRedirect: React.FC = () => {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  useEffect(() => {
+    const token = params.get('token');
+    const refresh = params.get('refreshToken');
+    if (token && refresh) {
+      login(token, refresh);
+      navigate('/examples');
+    } else {
+      navigate('/login');
+    }
+  }, [params, login, navigate]);
+
+  return <div>Authenticating...</div>;
+};
+
+export default AuthRedirect;

--- a/frontend/src/features/auth/ChangePassword.tsx
+++ b/frontend/src/features/auth/ChangePassword.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as yup from 'yup';
 import { useFormCommand } from '../../hooks/useFormCommand';
 import { validateRelatedFields } from '../../utils/validation';
+import { api } from '../../api';
 
 const ChangePassword: React.FC = () => {
   const [currentPassword, setCurrentPassword] = React.useState('');
@@ -22,12 +23,10 @@ const ChangePassword: React.FC = () => {
         }),
     }),
     api: async (values: { currentPassword: string; newPassword: string }) => {
-      const res = await fetch('/api/auth/change-password', {
+      await api('/api/auth/change-password', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(values)
       });
-      if (!res.ok) throw new Error('Could not change password');
     },
     onSuccess: () => setSuccess(true)
   });

--- a/frontend/src/features/auth/Login.tsx
+++ b/frontend/src/features/auth/Login.tsx
@@ -27,8 +27,10 @@ const Login: React.FC = () => {
         body: JSON.stringify(values)
       });
       if (!res.ok) throw new Error('Invalid credentials');
+      return res.json();
     },
-    onSuccess: login
+    onSuccess: (tokens: { accessToken: string; refreshToken: string }) =>
+      login(tokens.accessToken, tokens.refreshToken)
   });
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/frontend/src/pages/PromoCodes.tsx
+++ b/frontend/src/pages/PromoCodes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useReactTable, ColumnDef, getCoreRowModel } from '@tanstack/react-table';
+import { api } from '../api';
 
 interface PromoCode {
   PromoCode: string;
@@ -52,12 +53,10 @@ const PromoCodes: React.FC = () => {
     if (promoCode) params.append('promoCode', promoCode);
     if (status) params.append('status', status);
 
-    fetch(`/api/promocodes?${params.toString()}`)
-      .then(r => r.json())
-      .then((json: ApiResponse) => {
-        setData(json.Data);
-        setTotalPages(json.Pagination.TotalPages);
-      });
+    api<ApiResponse>(`/api/promocodes?${params.toString()}`).then(json => {
+      setData(json.Data);
+      setTotalPages(json.Pagination.TotalPages);
+    });
   }, [page, promoCode, status]);
 
   React.useEffect(() => {

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -5,6 +5,7 @@ import ChangePassword from '../features/auth/ChangePassword';
 import Examples from '../pages/Examples';
 import PromoCodes from '../pages/PromoCodes';
 import { useAuth } from '../store/auth';
+import AuthRedirect from '../features/auth/AuthRedirect';
 
 const AppRoutes: React.FC = () => {
   const { loggedIn } = useAuth();
@@ -12,6 +13,7 @@ const AppRoutes: React.FC = () => {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/auth" element={<AuthRedirect />} />
       <Route path="/change-password" element={loggedIn ? <ChangePassword /> : <Navigate to="/login" />} />
       <Route path="/examples" element={loggedIn ? <Examples /> : <Navigate to="/login" />} />
       <Route path="/promocodes" element={loggedIn ? <PromoCodes /> : <Navigate to="/login" />} />

--- a/frontend/src/store/auth.tsx
+++ b/frontend/src/store/auth.tsx
@@ -2,20 +2,41 @@ import React, { createContext, useContext, useState, ReactNode } from 'react';
 
 interface AuthContextValue {
   loggedIn: boolean;
-  login: () => void;
+  accessToken: string | null;
+  refreshToken: string | null;
+  login: (access: string, refresh: string) => void;
   logout: () => void;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
-export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const [loggedIn, setLoggedIn] = useState(false);
+let tokensRef: { accessToken: string; refreshToken: string } | null = null;
+export const getAuthTokens = () => tokensRef;
+export const setAuthTokens = (tokens: { accessToken: string; refreshToken: string } | null) => {
+  tokensRef = tokens;
+};
 
-  const login = () => setLoggedIn(true);
-  const logout = () => setLoggedIn(false);
+export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [tokens, setTokens] = useState<{ accessToken: string; refreshToken: string } | null>(null);
+
+  const login = (access: string, refresh: string) => {
+    const t = { accessToken: access, refreshToken: refresh };
+    setTokens(t);
+    setAuthTokens(t);
+  };
+  const logout = () => {
+    setTokens(null);
+    setAuthTokens(null);
+  };
 
   return (
-    <AuthContext.Provider value={{ loggedIn, login, logout }}>
+    <AuthContext.Provider value={{
+      loggedIn: !!tokens,
+      accessToken: tokens?.accessToken || null,
+      refreshToken: tokens?.refreshToken || null,
+      login,
+      logout
+    }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add JWT token pair generation and refresh validation on backend
- secure API calls in frontend and support automatic token refresh
- accept tokens from auth redirect and store in context

## Testing
- `dotnet build backend/backend.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c6741180832e9339e262c2d37d86