### PR TITLE
Add Zustand auth store and fetch current user after login

### DIFF
--- a/backend/Endpoints/UserEndpoints.cs
+++ b/backend/Endpoints/UserEndpoints.cs
@@ -1,0 +1,32 @@
+using backend.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Linq;
+
+namespace backend.Endpoints;
+
+public static class UserEndpoints
+{
+    public static void MapUserEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/api/users/me", (ClaimsPrincipal user) =>
+        {
+            var profile = new UserProfile
+            {
+                Id = user.FindFirstValue(JwtRegisteredClaimNames.Sub) ?? string.Empty,
+                Name = user.FindFirst("name")?.Value ?? string.Empty,
+                Email = user.FindFirst("email")?.Value ?? string.Empty
+            };
+
+            var menuJson = user.FindFirst("menu")?.Value;
+            var menu = string.IsNullOrEmpty(menuJson)
+                ? Enumerable.Empty<MenuItem>()
+                : JsonSerializer.Deserialize<IEnumerable<MenuItem>>(menuJson) ?? Enumerable.Empty<MenuItem>();
+
+            return Results.Ok(new { profile, menu });
+        }).RequireAuthorization();
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -110,6 +110,7 @@ app.MapAuthEndpoints();
 app.MapItemEndpoints();
 app.MapPromoCodeEndpoints();
 app.MapProductEndpoints();
+app.MapUserEndpoints();
 
 
 app.Run();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "react-select": "^5.7.3",
     "react-select-async-paginate": "^0.7.1",
     "@tanstack/react-table": "^8.9.1",
-    "yup": "^1.2.0"
+    "yup": "^1.2.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import { api } from './api';
 
 const AppContent: React.FC = () => {
   const navigate = useNavigate();
-  const { loggedIn, logout } = useAuth();
+  const { loggedIn, logout, user } = useAuth();
 
   const handleLogout = () => {
     api('/api/auth/logout', { method: 'POST' }).then(() => {
@@ -18,7 +18,12 @@ const AppContent: React.FC = () => {
 
   return (
     <MainLayout>
-      {loggedIn && <button onClick={handleLogout}>Logout</button>}
+      {loggedIn && (
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <span>{user ? `Welcome, ${user.name}` : 'Welcome'}</span>
+          <button onClick={handleLogout}>Logout</button>
+        </div>
+      )}
       <AppRoutes />
     </MainLayout>
   );

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,7 +1,7 @@
-import { getAuthTokens, setAuthTokens } from './store/auth';
+import { AuthTokens, useAuthStore } from './store/auth';
 
 export async function api<T>(url: string, options: RequestInit = {}, retry = true): Promise<T> {
-  const tokens = getAuthTokens();
+  const { tokens, setTokens } = useAuthStore.getState();
   const res = await fetch(url, {
     headers: {
       'Content-Type': 'application/json',
@@ -18,8 +18,8 @@ export async function api<T>(url: string, options: RequestInit = {}, retry = tru
       body: JSON.stringify({ refreshToken: tokens.refreshToken })
     });
     if (refreshRes.ok) {
-      const newTokens = await refreshRes.json();
-      setAuthTokens(newTokens);
+      const newTokens: AuthTokens = await refreshRes.json();
+      setTokens(newTokens);
       return api<T>(url, options, false);
     }
   }

--- a/frontend/src/features/auth/AuthRedirect.tsx
+++ b/frontend/src/features/auth/AuthRedirect.tsx
@@ -11,8 +11,14 @@ const AuthRedirect: React.FC = () => {
     const token = params.get('token');
     const refresh = params.get('refreshToken');
     if (token && refresh) {
-      login(token, refresh);
-      navigate('/examples');
+      void (async () => {
+        try {
+          await login(token, refresh);
+          navigate('/examples');
+        } catch {
+          navigate('/login');
+        }
+      })();
     } else {
       navigate('/login');
     }

--- a/frontend/src/features/auth/Login.tsx
+++ b/frontend/src/features/auth/Login.tsx
@@ -29,16 +29,21 @@ const Login: React.FC = () => {
       if (!res.ok) throw new Error('Invalid credentials');
       return res.json();
     },
-    onSuccess: (tokens: { accessToken: string; refreshToken: string }) =>
-      login(tokens.accessToken, tokens.refreshToken)
+    onSuccess: async (tokens: { accessToken: string; refreshToken: string }) => {
+      await login(tokens.accessToken, tokens.refreshToken);
+    }
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    const { errors } = await submit({ username, password });
-    if (errors) {
-      setError(Array.isArray(errors) ? errors.join(', ') : String(errors));
+    try {
+      const { errors } = await submit({ username, password });
+      if (errors) {
+        setError(Array.isArray(errors) ? errors.join(', ') : String(errors));
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to login');
     }
   };
 

--- a/frontend/src/hooks/useFormCommand.ts
+++ b/frontend/src/hooks/useFormCommand.ts
@@ -3,7 +3,7 @@ import * as yup from 'yup';
 export interface CommandConfig<T> {
   schema: yup.ObjectSchema<T>;
   api: (values: T) => Promise<any>;
-  onSuccess?: (result: any) => void;
+  onSuccess?: (result: any) => void | Promise<void>;
 }
 
 export function useFormCommand<T>(config: CommandConfig<T>) {
@@ -13,7 +13,9 @@ export function useFormCommand<T>(config: CommandConfig<T>) {
         abortEarly: false,
       });
       const result = await config.api(validated);
-      config.onSuccess?.(result);
+      if (config.onSuccess) {
+        await config.onSuccess(result);
+      }
       return { result };
     } catch (err: any) {
       if (err.name === 'ValidationError') {


### PR DESCRIPTION
## Summary
- add a new `/api/users/me` backend endpoint and register it so the frontend can retrieve authenticated user information
- replace the React auth context with a Zustand store that stores tokens, fetches the current user after login, and updates the shared API helper on refresh
- update the login and redirect flows to await the async auth logic, surface the signed-in user in the header, and allow async `onSuccess` handlers in the form helper

## Testing
- npm install *(fails: 403 Forbidden when downloading dependencies from registry.npmjs.org)*
- dotnet build backend/backend.csproj *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c955881434832e9fd94a2b32544f59